### PR TITLE
fix: typo in PermissionScreen.kt

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/PermissionScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/PermissionScreen.kt
@@ -105,7 +105,7 @@ fun PermissionScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 4.dp),
-                text = "2. Pleae grant access to the WhatsApp directory as shown in the picture below",
+                text = "2. Please grant access to the WhatsApp directory as shown in the picture below",
                 textAlign = TextAlign.Justify,
                 style = MaterialTheme.typography.bodyMedium,
             )


### PR DESCRIPTION
# PR Info

## Issue Details
Fixed a typo in permissions screen

## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [x] `./gradlew testDebug`

## Type of change

<!-- Please delete options that are not relevant -->

- **Bug Fix** <!--  non-breaking change which fixes an issue -->
