### PR TITLE
Fix WhatsApp directory check: allow if either Media or Databases fold…

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/MainActivity.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/MainActivity.kt
@@ -72,10 +72,7 @@ class MainActivity : ComponentActivity() {
                         Environment.getExternalStorageDirectory().absolutePath + File.separator + relativePath
 
                     viewModel.listDirectories(absolutePath).observeForever {
-                        if (it.toString().contains("/Media") &&
-                            it.toString()
-                                .contains("/Databases")
-                        ) {
+                        if (it.toString().contains("/Media")) {
                             contentResolver.takePersistableUriPermission(
                                 result.data!!.data!!,
                                 Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION


### PR DESCRIPTION
# PR Info

## Issue Details

Previously, the app required both 'Media/' and 'Databases/' directories to be present to select the WhatsApp folder, which caused issues if the user hadn't enabled backups. This update changes the condition to allow selection if either directory exists.


 **Fixes** #33 <!-- to automatically close the linked issue -->


## Tests
<!-- Run these tests -->
 - [ ] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [ ] `./gradlew testDebug`

## Type of change

<!-- Please delete options that are not relevant -->

- **Bug Fix** <!--  non-breaking change which fixes an issue -->



