### PR TITLE
Fix file auto-selection after deleting a document file

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -475,7 +475,7 @@ fun ItemListCard(
     val modifier = if (listFile.filePath.toString().contains(Constants.LIST_LOADING_INDICATION))
         Modifier.shimmer() else Modifier
 
-    LaunchedEffect (isSelected ){
+    LaunchedEffect(isSelected) {
         selected = isSelected
     }
 

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -473,6 +474,10 @@ fun ItemListCard(
 
     val modifier = if (listFile.filePath.toString().contains(Constants.LIST_LOADING_INDICATION))
         Modifier.shimmer() else Modifier
+
+    LaunchedEffect (isSelected ){
+        selected = isSelected
+    }
 
     Card(
         modifier = modifier


### PR DESCRIPTION
# PR Info

## Issue Details
In the column view of document files, after deleting a file, the next file is selected automatically. 

<!-- Please choose the relevant option -->

 - **Fixes** #34 <!-- to automatically close the linked issue -->

## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [x] `./gradlew spotlessApply

## Type of change

- **Bug Fix** <!--  non-breaking change which fixes an issue -->

## screenshots
### Before

https://github.com/user-attachments/assets/283dd7d6-95bc-4b2c-ac46-aedce1916ea7

### After 

https://github.com/user-attachments/assets/ed04710c-201e-497b-80ae-cae6ec7086da




