### PR TITLE
feat: add persistent toggle between grid and list view using DataStore

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
@@ -65,7 +65,6 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
         viewModelScope.launch {
             val current = storeData.isGridViewFlow.first()
             val toggled = !current
-            // Save the current view type to Store
             storeData.setGridViewPreference(toggled)
         }
     }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.Date
 
@@ -43,6 +44,9 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
 
     private val storeData = StoreData(application.applicationContext)
 
+    private val _isGridView = MutableStateFlow(false)
+    val isGridView: StateFlow<Boolean> = _isGridView.asStateFlow()
+
     private val _directoryItem =
         MutableStateFlow<ViewState<Pair<String, List<ListDirectory>>>>(ViewState.Loading)
     val directoryItem: StateFlow<ViewState<Pair<String, List<ListDirectory>>>> =
@@ -50,7 +54,19 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
 
     init {
         viewModelScope.launch(Dispatchers.Default) {
+            storeData.isGridViewFlow.collect {
+                _isGridView.value = it
+            }
             getDirectoryList()
+        }
+    }
+
+    fun toggleViewType() {
+        viewModelScope.launch {
+            val current = storeData.isGridViewFlow.first()
+            val toggled = !current
+            // Save the current view type to Store
+            storeData.setGridViewPreference(toggled)
         }
     }
 

--- a/app/src/main/java/com/vishnu/whatsappcleaner/data/StoreData.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/data/StoreData.kt
@@ -20,15 +20,19 @@
 package com.vishnu.whatsappcleaner.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 
 class StoreData(val context: Context) {
 
     companion object {
         private val Context.dataStore by preferencesDataStore(name = "store_data")
+        val IS_GRID_VIEW_KEY = booleanPreferencesKey("is_grid_view")
     }
 
     suspend fun set(key: String, value: String) {
@@ -40,4 +44,15 @@ class StoreData(val context: Context) {
     suspend fun get(key: String): String? = context.dataStore.data.first().get(
         stringPreferencesKey(key)
     )
+
+    suspend fun setGridViewPreference(isGridView: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[IS_GRID_VIEW_KEY] = isGridView
+        }
+    }
+
+    val isGridViewFlow: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[IS_GRID_VIEW_KEY] ?: false
+        }
 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/data/StoreData.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/data/StoreData.kt
@@ -53,6 +53,6 @@ class StoreData(val context: Context) {
 
     val isGridViewFlow: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
-            preferences[IS_GRID_VIEW_KEY] ?: false
+            preferences[IS_GRID_VIEW_KEY] ?: true
         }
 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
@@ -123,7 +124,7 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
     var showConfirmationDialog by remember { mutableStateOf(false) }
     var showSortDialog by remember { mutableStateOf(false) }
 
-    var isGridView by remember { mutableStateOf(true) }
+    val isGridView by viewModel.isGridView.collectAsState()
     var isAllSelected by remember { mutableStateOf(false) }
 
     LaunchedEffect(
@@ -192,7 +193,7 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                         .size(32.dp)
                         .padding(horizontal = 4.dp),
                     onClick = {
-                        isGridView = !isGridView
+                        viewModel.toggleViewType()
                     }
                 ) {
                     Icon(


### PR DESCRIPTION
# PR Info

## Issue Details
This PR saves the user's selected view type to DataStore.   Now, the user doesn't have to change the view type every time. 


<!-- Please choose the relevant option -->

 - **Fixes** #39 ---- <!-- to automatically close the linked issue -->

## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [x] `./gradlew testDebug`

## Type of change

<!-- Please delete options that are not relevant -->

- **New Feature** <!-- non-breaking change which adds functionality -->
