### PR TITLE
add tab layout and a collapsible banner on list scrolling. 

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -289,6 +289,10 @@ fun ItemGridCard(
         ) Modifier.shimmer()
         else Modifier
 
+        LaunchedEffect(isSelected) {
+            selected = isSelected
+        }
+
         Card(
             modifier = modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -21,21 +21,11 @@ package com.vishnu.whatsappcleaner.ui
 
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -44,19 +34,17 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -75,7 +63,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
@@ -90,17 +77,14 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
@@ -108,21 +92,17 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.MainViewModel
 import com.vishnu.whatsappcleaner.R
 import com.vishnu.whatsappcleaner.model.ListDirectory
 import com.vishnu.whatsappcleaner.model.ListFile
-import com.vishnu.whatsappcleaner.ui.theme.WhatsAppCleanerTheme
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 
@@ -161,18 +141,27 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
 
     val pagerState = rememberPagerState(
         initialPage = 0,
-        initialPageOffsetFraction = 0.0f,
-        pageCount = { tabs.size }
+        pageCount = {
+            if (listDirectory.hasSent) {
+                if (listDirectory.hasPrivate) 3
+                else 2
+            } else 1
+        }
     )
 
-    val listState = rememberLazyListState()
-    val gridState = rememberLazyGridState()
+    val gridStates = remember {
+        List(3) { LazyGridState() }
+    }
+    val listStates = remember {
+        List(3) { LazyListState() }
+    }
+
     val showHeader by remember {
         derivedStateOf {
             if (isGridView) {
-                gridState.firstVisibleItemIndex < 1
+                gridStates[pagerState.currentPage].firstVisibleItemIndex < 1
             } else {
-                listState.firstVisibleItemIndex < 1
+                listStates[pagerState.currentPage].firstVisibleItemIndex < 1
             }
         }
     }
@@ -220,7 +209,15 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 privateList.addAll(it)
             }
     }
-    
+
+    // Clearing selected items on tab change
+    LaunchedEffect(pagerState.currentPage) {
+        if (selectedItems.isNotEmpty() || isAllSelected) {
+            selectedItems.clear()
+            isAllSelected = false
+        }
+    }
+
     Scaffold(
         topBar = {
             DetailScreenTopBar(
@@ -248,7 +245,15 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 ),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Header Banner
+            // Progress Indicator
+            if (isInProgress) LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(8.dp),
+            )
+
+            // Banner
             AnimatedVisibility(
                 visible = showHeader,
             ) {
@@ -267,23 +272,34 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 )
             }
 
-
-            // Sticky Tabs
-            TabRow(selectedTabIndex = pagerState.currentPage) {
-                tabs.forEachIndexed { index, title ->
-                    Tab(
-                        text = { Text(title) },
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(index)
+            if (listDirectory.hasSent || listDirectory.hasPrivate) {
+                // Tabs
+                TabRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    selectedTabIndex = pagerState.currentPage,
+                ) {
+                    tabs.forEachIndexed { index, title ->
+                        Tab(
+                            text = {
+                                Text(
+                                    text = title,
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                            },
+                            selected = pagerState.currentPage == index,
+                            onClick = {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(index)
+                                }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
 
-            // HorizontalPager fills remaining space
+            // HorizontalPager
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier
@@ -322,13 +338,11 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                         )
                     }
 
-                    Spacer(modifier = Modifier.height(8.dp))
-
                     // Grid or List
                     if (list.isNotEmpty()) {
                         if (isGridView) {
                             LazyVerticalGrid(
-                                state = gridState,
+                                state = gridStates[page],
                                 modifier = Modifier.fillMaxSize(),
                                 columns = GridCells.Fixed(3)
                             ) {
@@ -341,7 +355,7 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                             }
                         } else {
                             LazyColumn(
-                                state = listState,
+                                state = listStates[page],
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 items(list) {
@@ -381,8 +395,7 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
             CleanUpButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .background(Color.Black),
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
                 navController = navController,
                 selectedItems = selectedItems,
                 onShowDialog = { showConfirmationDialog = true }
@@ -449,10 +462,10 @@ fun DetailScreenTopBar(
                     modifier = Modifier
                         .size(32.dp),
                     painter =
-                        if (isGridView)
-                            painterResource(id = R.drawable.ic_view_list)
-                        else
-                            painterResource(id = R.drawable.ic_grid_view),
+                    if (isGridView)
+                        painterResource(id = R.drawable.ic_view_list)
+                    else
+                        painterResource(id = R.drawable.ic_grid_view),
                     tint = MaterialTheme.colorScheme.primary,
                     contentDescription = "grid list view",
                 )
@@ -472,6 +485,7 @@ fun DetailScreenTopBar(
                     contentDescription = "sort",
                 )
             }
+            Spacer(modifier = Modifier.width(8.dp))
         }
     )
 }
@@ -487,7 +501,7 @@ fun CleanUpButton(
         modifier = modifier.padding(2.dp),
         colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
         shape = RoundedCornerShape(64.dp),
-        contentPadding = PaddingValues(12.dp),
+        contentPadding = PaddingValues(8.dp),
         onClick = {
             if (selectedItems.isNotEmpty())
                 onShowDialog()
@@ -517,7 +531,6 @@ fun CleanUpButton(
         )
     }
 }
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -809,29 +822,4 @@ fun ConfirmationDialog(
             }
         }
     }
-}
-
-
-@Preview(showBackground = true)
-@Composable
-private fun TopBarPreview() {
-
-    WhatsAppCleanerTheme {
-        CleanUpButton(
-            modifier = Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-            navController = rememberNavController(),
-            selectedItems = emptyList(),
-            onShowDialog = {}
-        )
-    }
-
-
-//    DetailScreenTopBar(
-//        title = "WhatsApp Cleaner",
-//        toggleGridView = {},
-//        isGridView = true,
-//        onSortClick = {}
-//    )
 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -20,19 +20,32 @@
 package com.vishnu.whatsappcleaner.ui
 
 import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -41,7 +54,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -59,15 +74,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
@@ -79,6 +100,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
@@ -86,16 +108,20 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.MainViewModel
 import com.vishnu.whatsappcleaner.R
 import com.vishnu.whatsappcleaner.model.ListDirectory
 import com.vishnu.whatsappcleaner.model.ListFile
+import com.vishnu.whatsappcleaner.ui.theme.WhatsAppCleanerTheme
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.text.DateFormat
@@ -126,6 +152,30 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
 
     val isGridView by viewModel.isGridView.collectAsState()
     var isAllSelected by remember { mutableStateOf(false) }
+
+    var currentList: SnapshotStateList<ListFile> = fileList
+
+    val tabs = listOf("Received", "Sent", "Private")
+
+    val coroutineScope = rememberCoroutineScope()
+
+    val pagerState = rememberPagerState(
+        initialPage = 0,
+        initialPageOffsetFraction = 0.0f,
+        pageCount = { tabs.size }
+    )
+
+    val listState = rememberLazyListState()
+    val gridState = rememberLazyGridState()
+    val showHeader by remember {
+        derivedStateOf {
+            if (isGridView) {
+                gridState.firstVisibleItemIndex < 1
+            } else {
+                listState.firstVisibleItemIndex < 1
+            }
+        }
+    }
 
     LaunchedEffect(
         isInProgress,
@@ -170,243 +220,140 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 privateList.addAll(it)
             }
     }
-
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
-    ) {
-        Column(
-            Modifier.padding(top = 16.dp, bottom = 8.dp, start = 16.dp, end = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Title(
-                    Modifier
-                        .padding(0.dp),
-                    listDirectory.name
-                )
-
-                Spacer(Modifier.weight(1f))
-
-                IconButton(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .padding(horizontal = 4.dp),
-                    onClick = {
-                        viewModel.toggleViewType()
-                    }
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .size(32.dp),
-                        painter =
-                        if (isGridView)
-                            painterResource(id = R.drawable.ic_view_list)
-                        else
-                            painterResource(id = R.drawable.ic_grid_view),
-                        tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "grid list view",
-                    )
-                }
-
-                IconButton(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .padding(horizontal = 4.dp),
-                    onClick = {
-                        showSortDialog = true
-
-                        // resetting everything for safety -- accidental selction & deletion
-                        dateRangePickerState.setSelection(null, null)
-                        selectedItems.clear()
-                        isAllSelected = false
-                    }
-                ) {
-                    Icon(
-                        modifier = Modifier
-                            .size(32.dp),
-                        painter = painterResource(id = R.drawable.ic_sort),
-                        tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "sort",
-                    )
-                }
-            }
-
-            Banner(
-                Modifier.padding(16.dp),
-                buildAnnotatedString {
-                    var size = listDirectory.size
-
-                    if (size.contains(" ")) {
-                        val split = size.split(" ")
-                        withStyle(SpanStyle(fontSize = 24.sp)) {
-                            append(split.get(0))
-                        }
-                        withStyle(SpanStyle(fontSize = 18.sp)) {
-                            append(" ${split.get(1)}")
-                        }
-                    } else {
-                        withStyle(SpanStyle(fontSize = 24.sp)) {
-                            append(size)
-                        }
-                    }
-                }
-            )
-
-            val pagerState = rememberPagerState(pageCount = {
-                if (listDirectory.hasSent)
-                    if (listDirectory.hasPrivate) 3
-                    else 2
-                else 1
-            })
-
-            var currentList: SnapshotStateList<ListFile> = fileList
-            val coroutineScope = rememberCoroutineScope()
-
-            if (listDirectory.hasSent || listDirectory.hasPrivate)
-                Row(
-                    modifier = Modifier.padding(8.dp),
-                    horizontalArrangement = Arrangement.SpaceEvenly
-                ) {
-                    val arr = arrayListOf("Received")
-
-                    if (listDirectory.hasSent)
-                        arr.add("Sent")
-
-                    if (listDirectory.hasPrivate)
-                        arr.add("Private")
-
-                    for (s in arr) {
-                        TextButton(
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxWidth()
-                                .padding(4.dp, 8.dp, 4.dp, 0.dp)
-                                .border(
-                                    BorderStroke(
-                                        2.dp,
-                                        if (arr[pagerState.settledPage] != s) MaterialTheme.colorScheme.primaryContainer
-                                        else MaterialTheme.colorScheme.background,
-                                    ),
-                                    RoundedCornerShape(64.dp),
-                                ),
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                containerColor = if (arr[pagerState.settledPage] == s) MaterialTheme.colorScheme.primaryContainer
-                                else MaterialTheme.colorScheme.background
-                            ),
-                            shape = RoundedCornerShape(64.dp),
-                            contentPadding = PaddingValues(vertical = 12.dp),
-                            onClick = {
-                                coroutineScope.launch {
-                                    pagerState.scrollToPage(
-                                        arr.indexOf(s)
-                                    )
-                                }
-                            }
-                        ) {
-                            Text(
-                                text = buildAnnotatedString {
-                                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.onPrimaryContainer)) {
-                                        append(s)
-                                    }
-                                },
-                                style = MaterialTheme.typography.headlineSmall,
-                            )
-                        }
-                    }
-                }
-
-            IconButton(
-                modifier = Modifier
-                    .align(Alignment.End)
-                    .padding(8.dp)
-                    .size(32.dp)
-                    .padding(4.dp),
-                onClick = {
-                    isAllSelected = !isAllSelected
-
-                    if (isAllSelected)
-                        selectedItems.addAll(currentList.toList())
-                    else
-                        selectedItems.clear()
-                }
-            ) {
-                Icon(
-                    modifier = Modifier
-                        .size(32.dp),
-                    painter = painterResource(id = if (isAllSelected) R.drawable.check_circle_filled else R.drawable.check_circle),
-                    tint = MaterialTheme.colorScheme.primary,
-                    contentDescription = "select all",
-                )
-            }
-
-            LaunchedEffect(pagerState) {
-                snapshotFlow {
-                    pagerState.currentPage
-                }.distinctUntilChanged().collect { _ ->
+    
+    Scaffold(
+        topBar = {
+            DetailScreenTopBar(
+                title = listDirectory.name,
+                toggleGridView = {
+                    viewModel.toggleViewType()
+                },
+                isGridView = isGridView,
+                onSortClick = {
+                    showSortDialog = true
+                    dateRangePickerState.setSelection(null, null)
                     selectedItems.clear()
                     isAllSelected = false
                 }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = innerPadding.calculateTopPadding(),
+                    start = innerPadding.calculateStartPadding(LayoutDirection.Ltr),
+                    end = innerPadding.calculateEndPadding(LayoutDirection.Ltr)
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Header Banner
+            AnimatedVisibility(
+                visible = showHeader,
+            ) {
+                Banner(
+                    Modifier.padding(16.dp),
+                    buildAnnotatedString {
+                        val size = listDirectory.size
+                        val parts = size.split(" ")
+                        if (parts.size == 2) {
+                            withStyle(SpanStyle(fontSize = 24.sp)) { append(parts[0]) }
+                            withStyle(SpanStyle(fontSize = 18.sp)) { append(" ${parts[1]}") }
+                        } else {
+                            withStyle(SpanStyle(fontSize = 24.sp)) { append(size) }
+                        }
+                    }
+                )
             }
 
-            if (isInProgress) LinearProgressIndicator(
+
+            // Sticky Tabs
+            TabRow(selectedTabIndex = pagerState.currentPage) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        text = { Text(title) },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                    )
+                }
+            }
+
+            // HorizontalPager fills remaining space
+            HorizontalPager(
+                state = pagerState,
                 modifier = Modifier
+                    .weight(1f)
                     .fillMaxWidth()
-                    .wrapContentHeight()
-                    .padding(8.dp),
-            )
+            ) { page ->
+                val list = when (page) {
+                    0 -> fileList
+                    1 -> sentList
+                    else -> privateList
+                }
 
-            key(isAllSelected) {
-                HorizontalPager(
-                    modifier = Modifier.weight(1f),
-                    state = pagerState
-                ) { page ->
+                currentList = list
 
-                    if (pagerState.currentPage == 0) {
-                        currentList = fileList
-                    } else if (pagerState.currentPage == 1) {
-                        currentList = sentList
-                    } else {
-                        currentList = privateList
+                Column(
+                    Modifier
+                        .fillMaxSize()
+                ) {
+                    // Select All Icon
+                    IconButton(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(8.dp)
+                            .size(32.dp),
+                        onClick = {
+                            isAllSelected = !isAllSelected
+                            if (isAllSelected) selectedItems.addAll(list)
+                            else selectedItems.clear()
+                        }
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(32.dp),
+                            painter = painterResource(id = if (isAllSelected) R.drawable.check_circle_filled else R.drawable.check_circle),
+                            tint = MaterialTheme.colorScheme.primary,
+                            contentDescription = "select all"
+                        )
                     }
 
-                    if (currentList.isNotEmpty()) {
-                        if (isGridView)
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    // Grid or List
+                    if (list.isNotEmpty()) {
+                        if (isGridView) {
                             LazyVerticalGrid(
+                                state = gridState,
                                 modifier = Modifier.fillMaxSize(),
-                                columns = GridCells.Fixed(3),
+                                columns = GridCells.Fixed(3)
                             ) {
-                                items(currentList) {
-                                    ItemGridCard(
-                                        it,
-                                        navController,
-                                        isSelected = selectedItems.contains(it)
-                                    ) {
-                                        if (selectedItems.contains(it))
-                                            selectedItems.remove(it)
-                                        else
-                                            selectedItems.add(it)
+                                items(list) {
+                                    ItemGridCard(it, navController, selectedItems.contains(it)) {
+                                        if (selectedItems.contains(it)) selectedItems.remove(it)
+                                        else selectedItems.add(it)
                                     }
                                 }
                             }
-                        else
+                        } else {
                             LazyColumn(
-                                modifier = Modifier.fillMaxSize(),
+                                state = listState,
+                                modifier = Modifier.fillMaxSize()
                             ) {
-                                items(currentList) {
-                                    ItemListCard(
-                                        it,
-                                        navController,
-                                        isSelected = selectedItems.contains(it)
-                                    ) {
-                                        if (selectedItems.contains(it))
-                                            selectedItems.remove(it)
-                                        else
-                                            selectedItems.add(it)
+                                items(list) {
+                                    ItemListCard(it, navController, selectedItems.contains(it)) {
+                                        if (selectedItems.contains(it)) selectedItems.remove(it)
+                                        else selectedItems.add(it)
                                     }
                                 }
                             }
+                        }
                     } else {
+                        // Empty state
                         Column(
                             modifier = Modifier.fillMaxSize(),
                             verticalArrangement = Arrangement.Center,
@@ -420,54 +367,26 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                                 contentDescription = "empty",
                                 tint = MaterialTheme.colorScheme.secondaryContainer
                             )
-
                             Text(
-                                modifier = Modifier,
                                 text = "Nothing to clean",
                                 fontSize = 24.sp,
-                                fontWeight = FontWeight.Medium,
+                                fontWeight = FontWeight.Medium
                             )
                         }
                     }
                 }
             }
 
-            TextButton(
+            // Clean-up button at bottom
+            CleanUpButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(8.dp),
-                colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-                shape = RoundedCornerShape(64.dp),
-                contentPadding = PaddingValues(12.dp),
-                onClick = {
-                    if (selectedItems.isNotEmpty())
-                        showConfirmationDialog = true
-                    else
-                        Toast.makeText(
-                            navController.context,
-                            "Select files to cleanup!",
-                            Toast.LENGTH_SHORT
-                        )
-                            .show()
-                }
-            ) {
-                Text(
-                    text = buildAnnotatedString {
-                        withStyle(
-                            SpanStyle(
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                fontWeight = FontWeight.Black,
-                                fontSize = 18.sp,
-                                letterSpacing = 1.sp
-                            )
-                        ) {
-                            append("Cleanup")
-                        }
-                    },
-                    fontWeight = FontWeight.Medium,
-                    style = MaterialTheme.typography.headlineMedium
-                )
-            }
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .background(Color.Black),
+                navController = navController,
+                selectedItems = selectedItems,
+                onShowDialog = { showConfirmationDialog = true }
+            )
         }
     }
 
@@ -505,6 +424,100 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
         )
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailScreenTopBar(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    toggleGridView: () -> Unit,
+    isGridView: Boolean,
+    onSortClick: () -> Unit
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = { Text(title) },
+        actions = {
+            IconButton(
+                modifier = Modifier
+                    .size(32.dp),
+                onClick = {
+                    toggleGridView()
+                }
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .size(32.dp),
+                    painter =
+                        if (isGridView)
+                            painterResource(id = R.drawable.ic_view_list)
+                        else
+                            painterResource(id = R.drawable.ic_grid_view),
+                    tint = MaterialTheme.colorScheme.primary,
+                    contentDescription = "grid list view",
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            IconButton(
+                modifier = Modifier
+                    .size(32.dp),
+                onClick = { onSortClick() }
+            ) {
+                Icon(
+                    modifier = Modifier.size(32.dp),
+                    painter = painterResource(id = R.drawable.ic_sort),
+                    tint = MaterialTheme.colorScheme.primary,
+                    contentDescription = "sort",
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun CleanUpButton(
+    modifier: Modifier = Modifier,
+    navController: NavHostController,
+    selectedItems: List<ListFile>,
+    onShowDialog: () -> Unit
+) {
+    TextButton(
+        modifier = modifier.padding(2.dp),
+        colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+        shape = RoundedCornerShape(64.dp),
+        contentPadding = PaddingValues(12.dp),
+        onClick = {
+            if (selectedItems.isNotEmpty())
+                onShowDialog()
+            else
+                Toast.makeText(
+                    navController.context,
+                    "Select files to cleanup!",
+                    Toast.LENGTH_SHORT
+                ).show()
+        }
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                withStyle(
+                    SpanStyle(
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        fontWeight = FontWeight.Black,
+                        fontSize = 18.sp,
+                        letterSpacing = 1.sp
+                    )
+                ) {
+                    append("Cleanup")
+                }
+            },
+            fontWeight = FontWeight.Medium,
+            style = MaterialTheme.typography.headlineMedium
+        )
+    }
+}
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -796,4 +809,29 @@ fun ConfirmationDialog(
             }
         }
     }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun TopBarPreview() {
+
+    WhatsAppCleanerTheme {
+        CleanUpButton(
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+            navController = rememberNavController(),
+            selectedItems = emptyList(),
+            onShowDialog = {}
+        )
+    }
+
+
+//    DetailScreenTopBar(
+//        title = "WhatsApp Cleaner",
+//        toggleGridView = {},
+//        isGridView = true,
+//        onSortClick = {}
+//    )
 }


### PR DESCRIPTION
# PR Info

## Issue Details
In the PR, I replaced the pager buttons with tabs. This avoids overflowing the text size that was the problem with the pager buttons. Besides this, I have implemented some other UI enhancements:

 -  Wrapped the screen with a  `Scaffold` composable, which handles the spacing around the topbar and main content on different screens. For example, some phones has a curve at the top for front camera, and it covers the topbar, but with scaffold, it adjust spaceing.
 
 -  Implemented a collapsible size banner; when we scroll the list, it collapse and provide more space for scrolling.

-   Added a separate composable for topbar. It makes code modular and cleaner.
 




<!-- Please choose the relevant option -->

 **Fixes** #36 <!-- to automatically close the linked issue -->

## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->


## Type of change

<!-- Please delete options that are not relevant -->

- **Bug Fix** <!--  non-breaking change which fixes an issue -->
  - UI improvement


https://github.com/user-attachments/assets/17b1e5e0-afdc-4b76-a70a-c5423be95374



