### PR TITLE
feat: improve Cleanup button UX with smooth color transition and disa…

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -23,6 +23,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
@@ -677,41 +678,48 @@ fun CheckedIcon(modifier: Modifier = Modifier) {
 @Composable
 fun CleanUpButton(
     modifier: Modifier = Modifier,
-    navController: NavHostController,
     selectedItems: List<ListFile>,
     onShowDialog: () -> Unit
 ) {
+    val isEnabled = selectedItems.isNotEmpty()
+
+    val containerColor by animateColorAsState(
+        targetValue = if (isEnabled)
+            MaterialTheme.colorScheme.primary
+        else
+            MaterialTheme.colorScheme.surfaceVariant,
+        label = "ContainerColorAnimation"
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isEnabled)
+            MaterialTheme.colorScheme.onPrimary
+        else
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        label = "ContentColorAnimation"
+    )
+
     TextButton(
         modifier = modifier.padding(2.dp),
-        colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+        colors = ButtonDefaults.textButtonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = containerColor,
+            disabledContentColor = contentColor
+        ),
         shape = RoundedCornerShape(64.dp),
         contentPadding = PaddingValues(8.dp),
+        enabled = isEnabled,
         onClick = {
-            if (selectedItems.isNotEmpty())
-                onShowDialog()
-            else
-                Toast.makeText(
-                    navController.context,
-                    "Select files to cleanup!",
-                    Toast.LENGTH_SHORT
-                ).show()
+            if (selectedItems.isNotEmpty()) onShowDialog()
         }
     ) {
         Text(
-            text = buildAnnotatedString {
-                withStyle(
-                    SpanStyle(
-                        color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        fontWeight = FontWeight.Black,
-                        fontSize = 18.sp,
-                        letterSpacing = 1.sp
-                    )
-                ) {
-                    append("Cleanup")
-                }
-            },
+            text = "Cleanup",
             fontWeight = FontWeight.Medium,
-            style = MaterialTheme.typography.headlineMedium
+            style = MaterialTheme.typography.titleLarge,
+            fontSize = 18.sp,
+            letterSpacing = 1.sp
         )
     }
 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -368,7 +368,6 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 4.dp),
-                navController = navController,
                 selectedItems = selectedItems,
                 onShowDialog = { showConfirmationDialog = true }
             )


### PR DESCRIPTION
# PR Info

## Issue Details

<!-- Please choose the relevant option -->

 - **Fixes** #46 ---- <!-- to automatically close the linked issue -->


## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [x] `./gradlew testDebug`

## Type of change

<!-- Please delete options that are not relevant -->

- **New Feature** <!-- non-breaking change which adds functionality -->

**Screenshots**

 Disabled |  Enabled 

<img src ="https://github.com/user-attachments/assets/a98da0d8-26ae-401e-b613-a3518b340e8d" width=300 />
<img src ="https://github.com/user-attachments/assets/e28bd937-b8fb-450e-a45e-e3bd9df02120" width=300 />


## Additional Info

- Added smooth colour transition for the Cleanup button using animateColorAsState.

- Disabled the Cleanup button when no items are selected to prevent unnecessary actions.

- Removed the Toast shown when the button was disabled because it won't display if the button is disabled.

<!-- Any additional info we should know about the PR! -->
