### PR TITLE
Fix PR template issue that prevents automatic closure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 <!-- Please choose the relevant option -->
 
- - **Fixes** #---- <!-- to automatically close the linked issue -->
+ - Fixes #---- <!-- to automatically close the linked issue -->
  - **Addresses** #---- <!-- to link the issue but not close - work pending etc. -->
 
 ## Tests


### PR DESCRIPTION
# PR Info

## Issue Details

<!-- Please choose the relevant option -->

 - `**Fixes** #---- <!-- to automatically close the linked issue -->`

The ** for bold text was in between preventing automatic closure

---

**A recommendation to use `Squash and Merge` instead of simple `Merge` for all PRs**

Also a request to make a new version release after merging the current open PR (`#50`)