### PR TITLE
feat: hide select-all button based on file presence

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -290,27 +290,31 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                     else -> privateList
                 }
 
+                val hasFiles = list.isNotEmpty()
+
                 Column(
                     Modifier
                         .fillMaxSize()
                 ) {
-                    IconButton(
-                        modifier = Modifier
-                            .align(Alignment.End)
-                            .padding(8.dp)
-                            .size(32.dp),
-                        onClick = {
-                            isAllSelected = !isAllSelected
-                            if (isAllSelected) selectedItems.addAll(list)
-                            else selectedItems.clear()
+                    if (hasFiles) {
+                        IconButton(
+                            modifier = Modifier
+                                .align(Alignment.End)
+                                .padding(8.dp)
+                                .size(32.dp),
+                            onClick = {
+                                isAllSelected = !isAllSelected
+                                if (isAllSelected) selectedItems.addAll(list)
+                                else selectedItems.clear()
+                            }
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(32.dp),
+                                painter = painterResource(id = if (isAllSelected) R.drawable.check_circle_filled else R.drawable.check_circle),
+                                tint = MaterialTheme.colorScheme.primary,
+                                contentDescription = "select all"
+                            )
                         }
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(32.dp),
-                            painter = painterResource(id = if (isAllSelected) R.drawable.check_circle_filled else R.drawable.check_circle),
-                            tint = MaterialTheme.colorScheme.primary,
-                            contentDescription = "select all"
-                        )
                     }
 
                     if (list.isNotEmpty()) {

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -290,13 +290,11 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                     else -> privateList
                 }
 
-                val hasFiles = list.isNotEmpty()
-
                 Column(
                     Modifier
                         .fillMaxSize()
                 ) {
-                    if (hasFiles) {
+                    if (list.isNotEmpty()) {
                         IconButton(
                             modifier = Modifier
                                 .align(Alignment.End)


### PR DESCRIPTION
# PR Info

## Issue Details

<!-- Please choose the relevant option -->

 - Fixes #48  ---- <!-- to automatically close the linked issue -->

## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->

## Type of change

<!-- Please delete options that are not relevant -->

- **New Feature** <!-- non-breaking change which adds functionality -->

## Screenshots
Hide | Show

<img src="https://github.com/user-attachments/assets/2be44b72-3faa-4fa8-a049-40d75e7cbc26" width=300/>
<img src= "https://github.com/user-attachments/assets/b6b1e97b-c3b0-4971-8b0a-26df0b9c9b5d" width=300/>


## Additional Info
- The select-all button is visible only when there are files in a tab. 

