### PR TITLE
fix: White Screen Flashing Glitch and add sliding animation

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/MainActivity.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/MainActivity.kt
@@ -34,6 +34,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -150,7 +156,7 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
 
                 NavHost(
-                    modifier = Modifier,
+                    modifier = Modifier.background(MaterialTheme.colorScheme.background),
                     navController = navController,
                     startDestination = startDestination
                 ) {
@@ -204,11 +210,39 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    composable(route = Constants.SCREEN_HOME) {
+                    composable(
+                        route = Constants.SCREEN_HOME,
+                        exitTransition = {
+                            slideOutOfContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Start,
+                                animationSpec = tween(durationMillis = 700)
+                            ) + fadeOut(animationSpec = tween(durationMillis = 700))
+                        },
+                        popEnterTransition = {
+                            slideIntoContainer(
+                                AnimatedContentTransitionScope.SlideDirection.End,
+                                animationSpec = tween(durationMillis = 700)
+                            ) + fadeIn(animationSpec = tween(durationMillis = 700))
+                        }
+                    ) {
                         HomeScreen(navController, viewModel)
                     }
 
-                    composable(route = Constants.SCREEN_DETAILS) {
+                    composable(
+                        route = Constants.SCREEN_DETAILS,
+                        enterTransition = {
+                            slideIntoContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Start,
+                                animationSpec = tween(durationMillis = 700)
+                            ) + fadeIn(animationSpec = tween(durationMillis = 700))
+                        },
+                        popExitTransition = {
+                            slideOutOfContainer(
+                                AnimatedContentTransitionScope.SlideDirection.End,
+                                animationSpec = tween(durationMillis = 700)
+                            ) + fadeOut(animationSpec = tween(durationMillis = 700))
+                        }
+                    ) {
                         DetailsScreen(navController, viewModel)
                     }
                 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/MainViewModel.kt
@@ -188,6 +188,12 @@ class MainViewModel(private val application: Application) : AndroidViewModel(app
             _fileReloadTrigger.value = !_fileReloadTrigger.value
         }
     }
+
+    fun clearFileListStates() {
+        _fileList.value = emptyList()
+        _sentList.value = emptyList()
+        _privateList.value = emptyList()
+    }
 }
 
 sealed class Target {

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -192,6 +193,12 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 dateRangePickerState.selectedStartDateMillis,
                 dateRangePickerState.selectedEndDateMillis
             )
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.clearFileListStates()
         }
     }
 


### PR DESCRIPTION
# PR Info

## Issue Details
Navigating from the Home screen to the Detail screen caused a visible white flash due to a slight rendering delay. 

The issue arose because the NavHost composable did not have a background colour set during the transition. When navigating from the Home screen to the Detail screen, there is a delay before the Detail screen renders. During this delay, the NavHost acts as the container for both screens and displays a white background. I’ve set `MaterialTheme.colorScheme.background` as a background colour to the NavHost to maintain visual consistency.

<!-- Please choose the relevant option -->

 - Fixes #55  ---- <!-- to automatically close the linked issue -->

## Screen Recording


https://github.com/user-attachments/assets/cd7fc805-9f94-4060-af0b-b6a61715327d



## Tests
<!-- Run these tests -->
 - [x] `./gradlew spotlessCheck` <!-- If this fails, run `./gradlew spotlessApply` -->
 - [ ] `./gradlew testDebug`

## Type of change

<!-- Please delete options that are not relevant -->

- **Bug Fix** <!--  non-breaking change which fixes an issue -->

## Additional Info


 - To enhance the user experience, I added a sliding transition animation between the Home and Detail screens. This provides a smoother transition compared to the default abrupt navigation. 
 - If this animation doesn’t align with the overall design guidelines of the app, I’m happy to adjust or remove it based on feedback.

<!-- Any additional info we should know about the PR! -->
