### PR TITLE
feat: confirmation dialog size total, per-item removal, and selection persistence

### DIFF
--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -842,7 +842,7 @@ fun CleanupConfirmationDialog(
         onConfirmation = onConfirmation,
         title = "Confirm Cleanup",
         message = "${selectedItemsSnapshot.size} files ($totalSize) will be deleted. " +
-            "Tap an item to remove it.",
+            "Tap the delete icon to remove an item.",
     ) {
         LazyVerticalGrid(
             modifier = Modifier
@@ -871,8 +871,7 @@ fun ConfirmationCard(
         modifier = Modifier
             .fillMaxWidth()
             .aspectRatio(1f)
-            .padding(8.dp)
-            .clickable(onClick = onRemove),
+            .padding(8.dp),
         shape = RoundedCornerShape(8.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
@@ -992,15 +991,16 @@ fun ConfirmationCard(
                     .size(22.dp)
                     .align(Alignment.TopEnd)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .background(MaterialTheme.colorScheme.onPrimary)
+                    .clickable(onClick = onRemove)
                     .zIndex(4f),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = "×",
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp
+                Icon(
+                    modifier = Modifier.size(18.dp),
+                    painter = painterResource(id = R.drawable.ic_delete),
+                    tint = MaterialTheme.colorScheme.primary,
+                    contentDescription = "remove item"
                 )
             }
         }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/Components.kt
@@ -44,6 +44,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
@@ -80,8 +83,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.zIndex
-import androidx.core.content.ContextCompat.startActivity
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.navigation.NavHostController
@@ -92,6 +96,7 @@ import com.valentinilk.shimmer.shimmer
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.R
 import com.vishnu.whatsappcleaner.ViewState
+import com.vishnu.whatsappcleaner.data.FileRepository
 import com.vishnu.whatsappcleaner.model.ListDirectory
 import com.vishnu.whatsappcleaner.model.ListFile
 import java.text.DateFormat
@@ -285,7 +290,7 @@ fun ItemGridCard(
     selectionEnabled: Boolean = true,
     toggleSelection: () -> Unit,
 ) {
-    key(listFile) {
+    key(listFile.uri) {
         // only for keeping track of the UI
         var selected by remember { mutableStateOf(isSelected) }
 
@@ -721,6 +726,284 @@ fun CleanUpButton(
             fontSize = 18.sp,
             letterSpacing = 1.sp
         )
+    }
+}
+
+@Composable
+fun ConfirmationDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmation: () -> Unit,
+    title: String,
+    message: String,
+    confirmText: String = "Confirm",
+    content: @Composable () -> Unit = {}
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnClickOutside = true,
+            dismissOnBackPress = true,
+            decorFitsSystemWindows = true
+        ),
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(vertical = 64.dp, horizontal = 32.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.wrapContentHeight(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Column(
+                        Modifier
+                            .weight(0.6f)
+                            .fillMaxWidth()
+                    ) {
+                        Text(
+                            modifier = Modifier
+                                .wrapContentHeight()
+                                .padding(vertical = 4.dp)
+                                .align(Alignment.Start),
+                            text = title,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+
+                        Text(
+                            modifier = Modifier
+                                .wrapContentHeight()
+                                .padding(vertical = 2.dp)
+                                .align(Alignment.Start),
+                            text = message,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+
+                    TextButton(
+                        modifier = Modifier
+                            .weight(0.4f)
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ),
+                        shape = RoundedCornerShape(16.dp),
+                        contentPadding = PaddingValues(vertical = 16.dp, horizontal = 16.dp),
+                        onClick = onConfirmation,
+                        content = {
+                            Text(
+                                text = confirmText,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                        },
+                    )
+                }
+
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+fun CleanupConfirmationDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmation: () -> Unit,
+    selectedItems: List<ListFile>,
+    context: Context,
+    onRemoveItem: (ListFile) -> Unit
+) {
+    val selectedItemsSnapshot = selectedItems.toList()
+
+    LaunchedEffect(selectedItemsSnapshot.isEmpty()) {
+        if (selectedItemsSnapshot.isEmpty()) onDismissRequest()
+    }
+
+    if (selectedItemsSnapshot.isEmpty()) return
+
+    val totalSize = remember(context, selectedItemsSnapshot) {
+        FileRepository.formatSize(context, selectedItemsSnapshot.sumOf { it.sizeBytes })
+    }
+
+    ConfirmationDialog(
+        onDismissRequest = onDismissRequest,
+        onConfirmation = onConfirmation,
+        title = "Confirm Cleanup",
+        message = "${selectedItemsSnapshot.size} files ($totalSize) will be deleted. " +
+            "Tap an item to remove it.",
+    ) {
+        LazyVerticalGrid(
+            modifier = Modifier
+                .wrapContentHeight(),
+            columns = GridCells.Fixed(3),
+        ) {
+            items(
+                items = selectedItemsSnapshot,
+                key = { it.uri }
+            ) { listFile ->
+                ConfirmationCard(listFile) {
+                    onRemoveItem(listFile)
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun ConfirmationCard(
+    listFile: ListFile,
+    onRemove: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .padding(8.dp)
+            .clickable(onClick = onRemove),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .clip(shape = RoundedCornerShape(8.dp))
+        ) {
+            if (listFile.extension.lowercase() in Constants.EXTENSIONS_IMAGE) GlideImage(
+                model = listFile.uri,
+                contentScale = ContentScale.Crop,
+                loading = placeholder(R.drawable.image),
+                failure = placeholder(R.drawable.error),
+                contentDescription = "confirmation list item"
+            )
+            else if (listFile.extension.lowercase() in Constants.EXTENSIONS_VIDEO) {
+                GlideImage(
+                    model = listFile.uri,
+                    contentScale = ContentScale.Crop,
+                    loading = placeholder(R.drawable.image),
+                    failure = placeholder(R.drawable.error),
+                    contentDescription = "confirmation list item"
+                )
+
+                Icon(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .align(Alignment.Center)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                        .padding(8.dp)
+                        .aspectRatio(1f)
+                        .zIndex(2f),
+                    painter = painterResource(id = R.drawable.video),
+                    contentDescription = "video",
+                )
+            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_DOCS) {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.document),
+                        contentDescription = "doc",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_AUDIO) {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.audio),
+                        contentDescription = "audio",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            } else {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.unknown),
+                        contentDescription = "unknown",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .size(22.dp)
+                    .align(Alignment.TopEnd)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .zIndex(4f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "×",
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -31,13 +31,10 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -53,7 +50,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -88,35 +84,25 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
-import com.bumptech.glide.integration.compose.placeholder
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.MainViewModel
 import com.vishnu.whatsappcleaner.R
 import com.vishnu.whatsappcleaner.Target
 import com.vishnu.whatsappcleaner.ViewState
-import com.vishnu.whatsappcleaner.data.FileRepository
 import com.vishnu.whatsappcleaner.model.ListDirectory
 import com.vishnu.whatsappcleaner.model.ListFile
 import kotlinx.coroutines.launch
@@ -368,7 +354,10 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                                     .padding(8.dp),
                                 columns = GridCells.Fixed(3)
                             ) {
-                                items(list) {
+                                items(
+                                    items = list,
+                                    key = { it.uri }
+                                ) {
                                     ItemGridCard(it, navController, selectedItems.contains(it)) {
                                         if (selectedItems.contains(it)) selectedItems.remove(it)
                                         else selectedItems.add(it)
@@ -382,7 +371,10 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                                     .fillMaxSize()
                                     .padding(8.dp)
                             ) {
-                                items(list) {
+                                items(
+                                    items = list,
+                                    key = { it.uri }
+                                ) {
                                     ItemListCard(it, navController, selectedItems.contains(it)) {
                                         if (selectedItems.contains(it)) selectedItems.remove(it)
                                         else selectedItems.add(it)
@@ -439,7 +431,7 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
     }
 
     if (showConfirmationDialog) {
-        ConfirmationDialog(
+        CleanupConfirmationDialog(
             onDismissRequest = {
                 // Preserve the selection when the dialog is dismissed without deleting,
                 // so the user does not have to re-select everything after a cancel.
@@ -452,7 +444,8 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                 selectedItems.clear()
             },
             selectedItems = selectedItems,
-            navController = navController
+            context = navController.context,
+            onRemoveItem = { selectedItems.remove(it) }
         )
     }
 }
@@ -705,260 +698,6 @@ fun SortDialog(
                         style = MaterialTheme.typography.bodyLarge
                     )
                 }
-            }
-        }
-    }
-}
-
-@Composable
-fun ConfirmationDialog(
-    onDismissRequest: () -> Unit,
-    onConfirmation: () -> Unit,
-    selectedItems: SnapshotStateList<ListFile>,
-    navController: NavHostController
-) {
-    // Auto-dismiss when the user has removed every item, so we never attempt an empty delete.
-    LaunchedEffect(selectedItems.isEmpty()) {
-        if (selectedItems.isEmpty()) onDismissRequest()
-    }
-
-    if (selectedItems.isEmpty()) return
-
-    val context = navController.context
-    val totalSize = remember(selectedItems.toList()) {
-        FileRepository.formatSize(context, selectedItems.sumOf { it.sizeBytes })
-    }
-
-    Dialog(
-        onDismissRequest = onDismissRequest,
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false,
-            dismissOnClickOutside = true,
-            dismissOnBackPress = true,
-            decorFitsSystemWindows = true
-        ),
-    ) {
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .padding(vertical = 64.dp, horizontal = 32.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.background)
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-                    .padding(16.dp),
-            ) {
-                Row(
-                    modifier = Modifier.wrapContentHeight(),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    Column(
-                        Modifier
-                            .weight(0.6f)
-                            .fillMaxWidth()
-                    ) {
-                        Text(
-                            modifier = Modifier
-                                .wrapContentHeight()
-                                .padding(vertical = 4.dp)
-                                .align(Alignment.Start),
-                            text = "Confirm Cleanup",
-                            style = MaterialTheme.typography.titleLarge,
-                        )
-
-                        Text(
-                            modifier = Modifier
-                                .wrapContentHeight()
-                                .padding(vertical = 2.dp)
-                                .align(Alignment.Start),
-                            text = "${selectedItems.size} files ($totalSize) will be deleted. Tap an item to remove it.",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-
-                    TextButton(
-                        modifier = Modifier
-                            .weight(0.4f)
-                            .fillMaxWidth()
-                            .padding(8.dp),
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                        ),
-                        shape = RoundedCornerShape(16.dp),
-                        contentPadding = PaddingValues(vertical = 16.dp, horizontal = 16.dp),
-                        onClick = onConfirmation,
-                        content = {
-                            Text(
-                                text = "Confirm",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Medium
-                            )
-                        },
-                    )
-                }
-
-                LazyVerticalGrid(
-                    modifier = Modifier
-                        .wrapContentHeight(),
-                    columns = GridCells.Fixed(3),
-                ) {
-                    items(selectedItems) { listFile ->
-                        ConfirmationCard(listFile) {
-                            selectedItems.remove(listFile)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalGlideComposeApi::class)
-@Composable
-fun ConfirmationCard(
-    listFile: ListFile,
-    onRemove: () -> Unit,
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(1f)
-            .padding(8.dp)
-            .clickable(onClick = onRemove),
-        shape = RoundedCornerShape(8.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Box(
-            Modifier
-                .fillMaxSize()
-                .clip(shape = RoundedCornerShape(8.dp))
-        ) {
-            if (listFile.extension.lowercase() in Constants.EXTENSIONS_IMAGE) GlideImage(
-                model = listFile.uri,
-                contentScale = ContentScale.Crop,
-                loading = placeholder(R.drawable.image),
-                failure = placeholder(R.drawable.error),
-                contentDescription = "confirmation list item"
-            )
-            else if (listFile.extension.lowercase() in Constants.EXTENSIONS_VIDEO) {
-                GlideImage(
-                    model = listFile.uri,
-                    contentScale = ContentScale.Crop,
-                    loading = placeholder(R.drawable.image),
-                    failure = placeholder(R.drawable.error),
-                    contentDescription = "confirmation list item"
-                )
-
-                Icon(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .align(Alignment.Center)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
-                        .padding(8.dp)
-                        .aspectRatio(1f)
-                        .zIndex(2f),
-                    painter = painterResource(id = R.drawable.video),
-                    contentDescription = "video",
-                )
-            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_DOCS) {
-                Column {
-                    Icon(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
-                            .fillMaxHeight()
-                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
-                            .padding(8.dp),
-                        painter = painterResource(id = R.drawable.document),
-                        contentDescription = "doc",
-                    )
-
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentHeight()
-                            .padding(8.dp),
-                        text = listFile.name,
-                        textAlign = TextAlign.Center,
-                        maxLines = 2,
-                        minLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_AUDIO) {
-                Column {
-                    Icon(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
-                            .fillMaxHeight()
-                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
-                            .padding(8.dp),
-                        painter = painterResource(id = R.drawable.audio),
-                        contentDescription = "audio",
-                    )
-
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentHeight()
-                            .padding(8.dp),
-                        text = listFile.name,
-                        textAlign = TextAlign.Center,
-                        maxLines = 2,
-                        minLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            } else {
-                Column {
-                    Icon(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
-                            .fillMaxHeight()
-                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
-                            .padding(8.dp),
-                        painter = painterResource(id = R.drawable.unknown),
-                        contentDescription = "unknown",
-                    )
-
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentHeight()
-                            .padding(8.dp),
-                        text = listFile.name,
-                        textAlign = TextAlign.Center,
-                        maxLines = 2,
-                        minLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            }
-
-            Box(
-                modifier = Modifier
-                    .padding(8.dp)
-                    .size(22.dp)
-                    .align(Alignment.TopEnd)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.errorContainer)
-                    .zIndex(4f),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = "×",
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp
-                )
             }
         }
     }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -445,7 +445,10 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
             },
             selectedItems = selectedItems,
             context = navController.context,
-            onRemoveItem = { selectedItems.remove(it) }
+            onRemoveItem = {
+                selectedItems.remove(it)
+                isAllSelected = false
+            }
         )
     }
 }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -332,8 +332,9 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
                                 .size(32.dp),
                             onClick = {
                                 isAllSelected = !isAllSelected
-                                if (isAllSelected) selectedItems.addAll(list)
-                                else selectedItems.clear()
+                                selectedItems.clear()
+                                if (isAllSelected)
+                                    selectedItems.addAll(list)
                             }
                         ) {
                             Icon(
@@ -433,8 +434,6 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
     if (showConfirmationDialog) {
         CleanupConfirmationDialog(
             onDismissRequest = {
-                // Preserve the selection when the dialog is dismissed without deleting,
-                // so the user does not have to re-select everything after a cancel.
                 showConfirmationDialog = false
             },
             onConfirmation = {

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -92,10 +94,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -103,6 +108,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+import com.bumptech.glide.integration.compose.placeholder
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.MainViewModel
 import com.vishnu.whatsappcleaner.R
@@ -800,35 +808,157 @@ fun ConfirmationDialog(
                     columns = GridCells.Fixed(3),
                 ) {
                     items(selectedItems) { listFile ->
-                        Box(
-                            modifier = Modifier.clickable { selectedItems.remove(listFile) }
-                        ) {
-                            ItemGridCard(
-                                listFile,
-                                navController,
-                                selectionEnabled = false
-                            ) {}
-
-                            Box(
-                                modifier = Modifier
-                                    .padding(12.dp)
-                                    .size(22.dp)
-                                    .align(Alignment.TopEnd)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.errorContainer)
-                                    .zIndex(4f),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = "×",
-                                    color = MaterialTheme.colorScheme.onErrorContainer,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 16.sp
-                                )
-                            }
+                        ConfirmationCard(listFile) {
+                            selectedItems.remove(listFile)
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun ConfirmationCard(
+    listFile: ListFile,
+    onRemove: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .padding(8.dp)
+            .clickable(onClick = onRemove),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .clip(shape = RoundedCornerShape(8.dp))
+        ) {
+            if (listFile.extension.lowercase() in Constants.EXTENSIONS_IMAGE) GlideImage(
+                model = listFile.uri,
+                contentScale = ContentScale.Crop,
+                loading = placeholder(R.drawable.image),
+                failure = placeholder(R.drawable.error),
+                contentDescription = "confirmation list item"
+            )
+            else if (listFile.extension.lowercase() in Constants.EXTENSIONS_VIDEO) {
+                GlideImage(
+                    model = listFile.uri,
+                    contentScale = ContentScale.Crop,
+                    loading = placeholder(R.drawable.image),
+                    failure = placeholder(R.drawable.error),
+                    contentDescription = "confirmation list item"
+                )
+
+                Icon(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .align(Alignment.Center)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                        .padding(8.dp)
+                        .aspectRatio(1f)
+                        .zIndex(2f),
+                    painter = painterResource(id = R.drawable.video),
+                    contentDescription = "video",
+                )
+            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_DOCS) {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.document),
+                        contentDescription = "doc",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            } else if (listFile.extension.lowercase() in Constants.EXTENSIONS_AUDIO) {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.audio),
+                        contentDescription = "audio",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            } else {
+                Column {
+                    Icon(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.6f))
+                            .padding(8.dp),
+                        painter = painterResource(id = R.drawable.unknown),
+                        contentDescription = "unknown",
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(8.dp),
+                        text = listFile.name,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        minLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .size(22.dp)
+                    .align(Alignment.TopEnd)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .zIndex(4f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "×",
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
             }
         }
     }

--- a/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/java/com/vishnu/whatsappcleaner/ui/DetailsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -50,6 +51,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -84,8 +86,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
@@ -97,12 +101,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
 import com.vishnu.whatsappcleaner.Constants
 import com.vishnu.whatsappcleaner.MainViewModel
 import com.vishnu.whatsappcleaner.R
 import com.vishnu.whatsappcleaner.Target
 import com.vishnu.whatsappcleaner.ViewState
+import com.vishnu.whatsappcleaner.data.FileRepository
 import com.vishnu.whatsappcleaner.model.ListDirectory
 import com.vishnu.whatsappcleaner.model.ListFile
 import kotlinx.coroutines.launch
@@ -427,17 +433,18 @@ fun DetailsScreen(navController: NavHostController, viewModel: MainViewModel) {
     if (showConfirmationDialog) {
         ConfirmationDialog(
             onDismissRequest = {
+                // Preserve the selection when the dialog is dismissed without deleting,
+                // so the user does not have to re-select everything after a cancel.
                 showConfirmationDialog = false
-                isAllSelected = false
-                selectedItems.clear()
             },
             onConfirmation = {
                 viewModel.delete(listDirectory, selectedItems.toList())
                 showConfirmationDialog = false
+                isAllSelected = false
                 selectedItems.clear()
             },
-            selectedItems,
-            navController
+            selectedItems = selectedItems,
+            navController = navController
         )
     }
 }
@@ -699,9 +706,21 @@ fun SortDialog(
 fun ConfirmationDialog(
     onDismissRequest: () -> Unit,
     onConfirmation: () -> Unit,
-    list: List<ListFile>,
+    selectedItems: SnapshotStateList<ListFile>,
     navController: NavHostController
 ) {
+    // Auto-dismiss when the user has removed every item, so we never attempt an empty delete.
+    LaunchedEffect(selectedItems.isEmpty()) {
+        if (selectedItems.isEmpty()) onDismissRequest()
+    }
+
+    if (selectedItems.isEmpty()) return
+
+    val context = navController.context
+    val totalSize = remember(selectedItems.toList()) {
+        FileRepository.formatSize(context, selectedItems.sumOf { it.sizeBytes })
+    }
+
     Dialog(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(
@@ -748,7 +767,7 @@ fun ConfirmationDialog(
                                 .wrapContentHeight()
                                 .padding(vertical = 2.dp)
                                 .align(Alignment.Start),
-                            text = "The following files will be deleted.",
+                            text = "${selectedItems.size} files ($totalSize) will be deleted. Tap an item to remove it.",
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }
@@ -775,13 +794,40 @@ fun ConfirmationDialog(
                     )
                 }
 
-                // todo: no preview & replace it with count + red colored CTA
                 LazyVerticalGrid(
                     modifier = Modifier
                         .wrapContentHeight(),
                     columns = GridCells.Fixed(3),
                 ) {
-                    items(list) { ItemGridCard(it, navController, selectionEnabled = false) {} }
+                    items(selectedItems) { listFile ->
+                        Box(
+                            modifier = Modifier.clickable { selectedItems.remove(listFile) }
+                        ) {
+                            ItemGridCard(
+                                listFile,
+                                navController,
+                                selectionEnabled = false
+                            ) {}
+
+                            Box(
+                                modifier = Modifier
+                                    .padding(12.dp)
+                                    .size(22.dp)
+                                    .align(Alignment.TopEnd)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.errorContainer)
+                                    .zIndex(4f),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "×",
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 16.sp
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8,9h8v10L8,19L8,9zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z" />
+</vector>


### PR DESCRIPTION
# PR Info

Updates the cleanup confirmation dialog (`ConfirmationDialog` in `DetailsScreen.kt`) with the three improvements requested in the issue:

- The header now shows how many files will be deleted and their summed total size, formatted with the existing `FileRepository.formatSize` helper.
- Each item in the confirmation grid is removable: tapping an item removes it from the deletion list, the count and total size update live, and the dialog auto-dismisses if every item is removed so an empty delete is never attempted.
- Dismissing the dialog without confirming (back press or tap outside) now preserves the current selection and select-all state, instead of clearing them. The clear-after-delete behavior on confirm is unchanged.

The dialog is reached from the Cleanup button on the details screen, which opens it via the `onShowDialog` callback wired to `showConfirmationDialog`.

## Issue Details

 - Fixes #69

## Tests

These run in CI (`spotlessCheck` then `testDebug`) on every push:
 - `./gradlew spotlessCheck`
 - `./gradlew testDebug`

Manual verification scenarios:
 - Open the dialog with several files selected: header shows the summed, human-readable total size and file count.
 - Remove an item in the dialog: it disappears, the total and count update, and that file is excluded from deletion on confirm.
 - Dismiss without confirming: the prior selection and select-all state remain intact.
 - Confirm deletion: selected files are deleted and the selection clears afterward (unchanged).
 - Remove every item: the dialog dismisses without attempting an empty delete.

## Type of change

- **New Feature**

## Additional Info

Change is confined to `DetailsScreen.kt`. The heavy Gradle build was not run locally; CI validates formatting and the build.
